### PR TITLE
Fix ref parsing in items

### DIFF
--- a/Sources/SwaggerSwiftML/Models/Items.swift
+++ b/Sources/SwaggerSwiftML/Models/Items.swift
@@ -98,7 +98,9 @@ public struct Items: Decodable {
             let properties = try container.decodeIfPresent([String: NodeWrapper<Schema>].self,
                                                            forKey: .properties)?.compactMapValues { $0.value }
 
-            self.type = .object(required: required ?? [], properties: properties ?? [:], allOf: allOf)
+            self.type = .object(required: required ?? [],
+                                properties: properties ?? [:],
+                                allOf: allOf)
         default:
             throw SwaggerParseError.invalidField(typeString ?? "No field found on Items")
         }

--- a/Sources/SwaggerSwiftML/Models/Schema.swift
+++ b/Sources/SwaggerSwiftML/Models/Schema.swift
@@ -166,10 +166,10 @@ public struct Schema: Decodable {
             let collectionFormat = (try container.decodeIfPresent(CollectionFormat.self, forKey: .collectionFormat)) ?? .csv
 
             let node: Node<Items>
-            if let itemsObject = try? container.decode(Items.self, forKey: .items) {
-                node = .node(itemsObject)
-            } else if let ref = try? container.decode(Reference.self, forKey: .items) {
+            if let ref = try? container.decode(Reference.self, forKey: .items) {
                 node = .reference(ref.ref)
+            } else if let itemsObject = try? container.decode(Items.self, forKey: .items) {
+                node = .node(itemsObject)
             } else {
                 throw SwaggerError.corruptFile
             }


### PR DESCRIPTION
SwaggerSwift wouldn't parse a ref if there was an object definition on an items field like:
```
items:
  type: object
  ref: ...
```

in this case the ref would be ignored. This is now changed.