### PR TITLE
Make description not mandatory on security definition

### DIFF
--- a/Sources/SwaggerSwiftML/Models/SecurityDefinition.swift
+++ b/Sources/SwaggerSwiftML/Models/SecurityDefinition.swift
@@ -1,6 +1,6 @@
 public struct SecurityDefinition: Decodable {
     public let type: String
-    public let description: String
+    public let description: String?
     public let name: String
     public let `in`: String
 }


### PR DESCRIPTION
Currently, the description is mandatory for the security definition while the on the [OpenAPI specification it is not](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#securitySchemeObject).

I am currently using an open source project for generating the swagger spec from code, but it currently does not support description for the security definition and then the iOS app is failing to generate the stubs from the mentioned file.

I will for sure do a contribution to the open source library, but I cannot push them to release it soon.
*EDIT*: Added the PR for the open source library [here](https://github.com/swaggo/swag/pull/1174)

Disclaimer: I have a Windows machine and I don't know Swift, but maybe this is enough.

