### PR TITLE
✨ Add multi collection format support

### DIFF
--- a/Sources/SwaggerSwiftML/Models/CollectionFormat.swift
+++ b/Sources/SwaggerSwiftML/Models/CollectionFormat.swift
@@ -3,6 +3,7 @@ public enum CollectionFormat: String, Codable {
     case ssv
     case tsv
     case pipes
+    case multi
 }
 
 extension CollectionFormat: Equatable {}


### PR DESCRIPTION
## Problem
The `CollectionFormat` enum is missing the `multi` case from the Swagger 2.0 spec. This means parameters with `collectionFormat: multi` cannot be parsed.

## Solution
Added `case multi` to the `CollectionFormat` enum.

## Testing
Builds successfully. The `multi` format means each array value is sent as a separate query parameter (e.g., `?color=red&color=blue`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive model change; main risk is behavior changes for any code that switches exhaustively over `CollectionFormat` without a `default`.
> 
> **Overview**
> Adds Swagger 2.0 `collectionFormat: multi` support by extending the `CollectionFormat` enum with a new `multi` case, allowing decoding/parsing of `multi` array parameters instead of failing on unknown values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0fee154e0659a542cd0e82f9592c5aaadf45517. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->